### PR TITLE
prep_void_rpi.sh may format the main drive in case of an inattention

### DIFF
--- a/void_3b+/prep_void_rpi.sh
+++ b/void_3b+/prep_void_rpi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Installs rootfs void linux image to a drive.
 
-PIDRIVE='/dev/sda';
+PIDRIVE='/dev/sdX';
 PIPART1=$PIDRIVE'1';
 PIPART2=$PIDRIVE'2';
 PIVER=$([ -n "$1" ] && echo "$1" || echo '3');

--- a/void_3b+/prep_void_rpi.sh
+++ b/void_3b+/prep_void_rpi.sh
@@ -35,7 +35,7 @@ echo 'unpacking...';
 sudo tar xvfJp "$IMG" -C rootfs/ > '/dev/null' && sync;
 
 echo 'adding boot entry...';
-echo "$PIPART1 /boot vfat defaults 0 0" | sudo tee -a rootfs/etc/fstab;
+echo "/dev/mmcblk0p1 /boot vfat defaults 0 0" | sudo tee -a rootfs/etc/fstab;
 
 echo 'adding boot options...';
 echo '


### PR DESCRIPTION
So, I replaced /dev/sda as /dev/sdX to prevent that.